### PR TITLE
Implement Service Binding in AmphibianCoreService

### DIFF
--- a/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
+++ b/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
@@ -2,6 +2,7 @@ package com.landseek.amphibian.service
 
 import android.app.Service
 import android.content.Intent
+import android.os.Binder
 import android.os.IBinder
 import android.util.Log
 import kotlinx.coroutines.*
@@ -25,6 +26,7 @@ class AmphibianCoreService : Service() {
     private var nodeProcess: Process? = null
     private var webSocket: WebSocket? = null
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val binder = LocalBinder()
     
     // Config
     private val PORT = 3000
@@ -131,8 +133,11 @@ class AmphibianCoreService : Service() {
     }
 
     override fun onBind(intent: Intent?): IBinder? {
-        // TODO: Return Binder for UI communication
-        return null
+        return binder
+    }
+
+    inner class LocalBinder : Binder() {
+        fun getService(): AmphibianCoreService = this@AmphibianCoreService
     }
     
     // Java 9+ ProcessHandle workaround for older Android APIs if needed


### PR DESCRIPTION
Implemented `onBind` in `AmphibianCoreService.kt` by creating a `LocalBinder` class and returning an instance of it. This enables clients (like Activities) to bind to the service and interact with its public methods.

---
*PR created automatically by Jules for task [14149408776134037255](https://jules.google.com/task/14149408776134037255) started by @Kaleaon*