### PR TITLE
Implement Node.js binary extraction from assets

### DIFF
--- a/android/app/src/main/assets/node-bin/node
+++ b/android/app/src/main/assets/node-bin/node
@@ -1,0 +1,1 @@
+dummy node binary

--- a/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
+++ b/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.*
 import okhttp3.*
 import org.json.JSONObject
 import java.io.File
+import java.io.FileOutputStream
 import java.util.concurrent.TimeUnit
 
 /**
@@ -51,8 +52,20 @@ class AmphibianCoreService : Service() {
         // Simulating extraction logic
         if (!nodeBin.exists()) {
             Log.d(TAG, "Extracting Node binary from assets...")
-            // TODO: AssetManager.open("node-bin/node").copyTo(nodeBin)
-            // nodeBin.setExecutable(true)
+            try {
+                assets.open("node-bin/node").use { inputStream ->
+                    FileOutputStream(nodeBin).use { outputStream ->
+                        inputStream.copyTo(outputStream)
+                    }
+                }
+                if (nodeBin.setExecutable(true)) {
+                    Log.d(TAG, "Node binary extracted and made executable.")
+                } else {
+                    Log.w(TAG, "Failed to make Node binary executable.")
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to extract Node binary", e)
+            }
         }
     }
 


### PR DESCRIPTION
Implemented the extraction of the Node.js binary from Android assets in `AmphibianCoreService.kt`.

Changes:
1.  Created `android/app/src/main/assets/node-bin/node` (dummy binary).
2.  Modified `android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt`:
    -   Implemented `bootstrapRuntime` to extract the asset `node-bin/node` to `filesDir/bin/node`.
    -   Added error handling and executable permission setting.
    -   Added `java.io.FileOutputStream` import.

---
*PR created automatically by Jules for task [12011639255570275558](https://jules.google.com/task/12011639255570275558) started by @Kaleaon*