### PR TITLE
⚡ [Performance] Use non-blocking delay in AmphibianCoreService

### DIFF
--- a/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
+++ b/android/app/src/main/java/com/landseek/amphibian/service/AmphibianCoreService.kt
@@ -83,9 +83,9 @@ class AmphibianCoreService : Service() {
         }
     }
 
-    private fun connectBridge() {
+    private suspend fun connectBridge() {
         // Wait a moment for Node to boot
-        Thread.sleep(2000)
+        delay(2000)
         
         val client = OkHttpClient.Builder()
             .readTimeout(0, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Replaced `Thread.sleep(2000)` with `delay(2000)` in `AmphibianCoreService.connectBridge` to prevent blocking the `Dispatchers.IO` thread pool. The function is now `suspend` and properly integrated into the existing coroutine scope. This improves resource utilization during service startup.

---
*PR created automatically by Jules for task [10245627492821333852](https://jules.google.com/task/10245627492821333852) started by @Kaleaon*