### PR TITLE
Replace TODO in StitchAdapter with functional println

### DIFF
--- a/bridge/mcp_servers/stitch_adapter.js
+++ b/bridge/mcp_servers/stitch_adapter.js
@@ -110,7 +110,7 @@ fun GeneratedScreen() {
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text(text = "${prompt}", style = MaterialTheme.typography.headlineMedium)
         Spacer(modifier = Modifier.height(16.dp))
-        Button(onClick = { /* TODO */ }) {
+        Button(onClick = { println("Action clicked for ${prompt}") }) {
             Text("Action")
         }
     }


### PR DESCRIPTION
Replaced `/* TODO */` with `println("Action clicked for ${prompt}")` in `bridge/mcp_servers/stitch_adapter.js`. Validated by running a test script that instantiated the adapter and checked the generated output.

---
*PR created automatically by Jules for task [6073679214865745879](https://jules.google.com/task/6073679214865745879) started by @Kaleaon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Button click handler now properly executes and outputs information to the console when clicked, instead of remaining inactive.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->