### PR TITLE
⚡ Optimize Router with Intent Caching

### DIFF
--- a/bridge/brains/lru_cache.js
+++ b/bridge/brains/lru_cache.js
@@ -1,0 +1,36 @@
+/**
+ * Simple LRU Cache implementation
+ */
+class LRUCache {
+    constructor(limit = 100) {
+        this.limit = limit;
+        this.cache = new Map();
+    }
+
+    get(key) {
+        if (!this.cache.has(key)) return null;
+
+        const value = this.cache.get(key);
+        // Refresh: remove and re-insert to update "recent-ness"
+        this.cache.delete(key);
+        this.cache.set(key, value);
+        return value;
+    }
+
+    set(key, value) {
+        if (this.cache.has(key)) {
+            this.cache.delete(key);
+        } else if (this.cache.size >= this.limit) {
+            // Evict the oldest (first inserted)
+            const firstKey = this.cache.keys().next().value;
+            this.cache.delete(firstKey);
+        }
+        this.cache.set(key, value);
+    }
+
+    clear() {
+        this.cache.clear();
+    }
+}
+
+module.exports = LRUCache;


### PR DESCRIPTION
💡 **What:**
Implemented an LRU (Least Recently Used) cache for the `MultiBrain` router. The cache stores the results of intent classification (routing decisions) based on the user's input task. It has a capacity of 50 items.

🎯 **Why:**
Routing requests to the appropriate tool involves an LLM call (`localBrain.chat`), which can be slow and resource-intensive. For repeated or identical requests, this overhead is unnecessary. Caching the decision significantly reduces latency and load on the LLM.

📊 **Measured Improvement:**
I created a benchmark simulating a 200ms latency for the LLM call.
- **Baseline (Cold Start):** ~202ms
- **Cached Request:** 0-1ms
- **Improvement:** Reduced latency by >99% for cache hits.

Functionality was verified with a correctness test suite covering cache hits, misses, and eviction.

---
*PR created automatically by Jules for task [4412937397257963032](https://jules.google.com/task/4412937397257963032) started by @Kaleaon*