### PR TITLE
feat: Broadcast bridge messages to UI via SharedFlow

### DIFF
--- a/android/app/src/main/java/com/landseek/amphibian/ui/MainActivity.kt
+++ b/android/app/src/main/java/com/landseek/amphibian/ui/MainActivity.kt
@@ -17,30 +17,62 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.landseek.amphibian.service.AmphibianCoreService
 import android.content.Intent
+import android.content.ServiceConnection
+import android.content.ComponentName
+import android.content.Context
+import android.os.IBinder
 
 class MainActivity : ComponentActivity() {
+
+    private var coreService by mutableStateOf<AmphibianCoreService?>(null)
+
+    private val connection = object : ServiceConnection {
+        override fun onServiceConnected(className: ComponentName, service: IBinder) {
+            val binder = service as AmphibianCoreService.LocalBinder
+            coreService = binder.getService()
+        }
+
+        override fun onServiceDisconnected(arg0: ComponentName) {
+            coreService = null
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         
         // Auto-start the Brain Service
-        startForegroundService(Intent(this, AmphibianCoreService::class.java))
+        val intent = Intent(this, AmphibianCoreService::class.java)
+        startForegroundService(intent)
+        bindService(intent, connection, Context.BIND_AUTO_CREATE)
 
         setContent {
             MaterialTheme(colorScheme = darkColorScheme()) {
-                AmphibianApp()
+                AmphibianApp(coreService)
             }
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unbindService(connection)
     }
 }
 
 @Composable
-fun AmphibianApp() {
+fun AmphibianApp(service: AmphibianCoreService?) {
     var input by remember { mutableStateOf("") }
     val messages = remember { mutableStateListOf<Message>() }
 
     // Mock initial message
     LaunchedEffect(Unit) {
         messages.add(Message("Amphibian Agent", "Core systems online. Node.js bridge active. 🐸", true))
+    }
+
+    // Listen to Agent messages
+    LaunchedEffect(service) {
+        service?.messageFlow?.collect { msg ->
+            messages.add(Message("Amphibian Agent", msg, true))
+        }
     }
 
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
@@ -76,7 +108,7 @@ fun AmphibianApp() {
                 keyboardActions = KeyboardActions(onSend = {
                     if (input.isNotBlank()) {
                         messages.add(Message("You", input, false))
-                        // TODO: Send to Service via Bridge
+                        service?.executeTask(input)
                         input = ""
                     }
                 })
@@ -84,7 +116,7 @@ fun AmphibianApp() {
             Button(onClick = {
                 if (input.isNotBlank()) {
                     messages.add(Message("You", input, false))
-                    // TODO: Send to Service via Bridge
+                    service?.executeTask(input)
                     input = ""
                 }
             }) {


### PR DESCRIPTION
This PR implements the logic to broadcast incoming WebSocket messages from `AmphibianCoreService` to `MainActivity` so they can be displayed in the UI.

Changes:
1.  **`AmphibianCoreService.kt`**:
    *   Implemented the `Binder` pattern with `LocalBinder`.
    *   Added a `SharedFlow` (`messageFlow`) to emit incoming messages.
    *   Updated `onMessage` to emit received text to the flow.
    *   Updated `onBind` to return the binder.

2.  **`MainActivity.kt`**:
    *   Implemented `ServiceConnection` to bind to `AmphibianCoreService`.
    *   Passed the service instance to `AmphibianApp` composable.
    *   Used `LaunchedEffect` to collect `messageFlow` and update the chat list.
    *   Connected the "Send" button to `service.executeTask()`.

This ensures that messages from the "Brain" are visible to the user.

---
*PR created automatically by Jules for task [4480936909795531786](https://jules.google.com/task/4480936909795531786) started by @Kaleaon*