### PR TITLE
Replace release build type signing with proper release configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,6 +7,24 @@ android {
     namespace 'com.landseek.amphibian'
     compileSdk 35
 
+    // Load signing properties from local.properties
+    def keystorePropertiesFile = rootProject.file('local.properties')
+    def keystoreProperties = new Properties()
+    if (keystorePropertiesFile.exists()) {
+        keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+    }
+
+    signingConfigs {
+        release {
+            if (keystoreProperties.containsKey('storeFile')) {
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+            }
+        }
+    }
+
     defaultConfig {
         applicationId "com.landseek.amphibian"
         minSdk 29
@@ -32,7 +50,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             
             // Signing config for release (configure in local.properties)
-            signingConfig signingConfigs.debug // TODO: Replace with release signing
+            if (signingConfigs.release.storeFile != null) {
+                signingConfig signingConfigs.release
+            } else {
+                signingConfig signingConfigs.debug
+            }
         }
         debug {
             debuggable true


### PR DESCRIPTION
The release build type in `android/app/build.gradle` was using the debug signing configuration. I updated it to use a dedicated `release` signing configuration that pulls its credentials from `local.properties`. This follows security best practices by keeping sensitive information out of version control while allowing for a seamless production build process. I also implemented a fallback to debug signing to ensure the build remains functional even if release credentials aren't locally configured.

---
*PR created automatically by Jules for task [7645059765052513952](https://jules.google.com/task/7645059765052513952) started by @Kaleaon*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Android build signing configuration to support release-specific signing credentials. Release builds now utilize dedicated signing configuration when credentials are provided, with automatic fallback to debug signing when unavailable. This enhancement strengthens build pipeline security and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->